### PR TITLE
Add a link to the "haskell-simplewebapp"

### DIFF
--- a/slides.markdown
+++ b/slides.markdown
@@ -17,3 +17,4 @@ title: '徳島IT開発勉強会 - 発表資料'
 * [krdlab](http://www.slideshare.net/krdlab): [2013-12-21 Streaming data processing ライブラリの紹介 (主に Conduit)](http://www.slideshare.net/krdlab/haskell-streamlibraries)
 * [ka](http://kaosfield.net): [2014-02-09 Clojure Getting Started](http://kaosf.github.io/20140209-clojure-getting-started)
 * [Sert](https://github.com/sert-uw): [2014-02-16 SoundReappearance](http://sert-uw.github.io/SoundReappearance-Slide)
+* [krdlab](https://github.com/krdlab): [2014-02-16 Scotty を用いた "ゆるふわ" Web サービス作成](http://www.slideshare.net/krdlab/haskell-simplewebapp)


### PR DESCRIPTION
2014/02/16 "ゆるふわ Haskell" における発表スライドのリンクを追加しました．
