### PR TITLE
Update "Development" section in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ local.properties
 
 # Jekyll
 _site
+
+# Bundler
+vendor

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ http://devtokushima.github.io
 ## Development (開発方法)
 
 1. Ruby をインストールする
-2. gem で Bundler をインストールする
-3. `bundle install` コマンドをこのリポジトリのディレクトリ内で実行
-4. `jekyll serve --watch` コマンドを実行
+2. `gem install bundler`
+3. `bundle install --path vendor/bundle` をこのリポジトリのディレクトリ内で実行
+4. `bundle exec jekyll serve --watch`
 5. ウェブブラウザで [http://localhost:4000](http://localhost:4000) にアクセス
 6. 編集作業を行う -> ブラウザを更新して確認 (これを繰り返し)
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+exclude: ['.bundle', '.git', '.gitignore', 'Gemfile', 'Gemfile.lock', 'LICENSE', 'README.md', 'vendor']


### PR DESCRIPTION
bundle install に "--path" オプションを指定し，bundle exec で Jekyll を起動する方法に変更してみてはいかがでしょうか？
これにより，作業ディレクトリ中に依存モジュールがインストールされるため削除も簡単になり，より気軽にはじめられると思います．
